### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
 			
       <nav>
         <ul>
-          <li><a href="http://pecan.readthedocs.org/en/latest/installation.html">Download</a></li>
-          <li><a href="http://pecan.readthedocs.org">Documentation</a></li>
+          <li><a href="https://pecan.readthedocs.io/en/latest/installation.html">Download</a></li>
+          <li><a href="https://pecan.readthedocs.io">Documentation</a></li>
           <li><a href="https://groups.google.com/forum/#!forum/pecan-dev">Mailing List</a></li>
           <li><a href="http://github.com/stackforge/pecan">Source</a></li>
         </ul>
@@ -65,7 +65,7 @@
 	</section>
 
   <div class="notice">
-    <p><a href="http://pecan.readthedocs.org">Check out our documentation</a> or <a href="http://github.com/stackforge/pecan/">view our project on github</a></p>
+    <p><a href="https://pecan.readthedocs.io">Check out our documentation</a> or <a href="http://github.com/pecan/pecan/">view our project on github</a></p>
   </div>
 	
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6/jquery.min.js"></script>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
